### PR TITLE
fix `defp` and `defprotocol` snippet conflict

### DIFF
--- a/snippets/language-elixir.cson
+++ b/snippets/language-elixir.cson
@@ -30,7 +30,7 @@
     'prefix': 'mdoc'
     'body': '@moduledoc """\n$0\n"""'
   'defprotocol':
-    'prefix': 'defp'
+    'prefix': 'defpro'
     'body': 'defprotocol $1 do\n\t$0\nend'
   'defimpl':
     'prefix': 'defi'


### PR DESCRIPTION
The `defprotocol` snippet's trigger was set to `defp`, which was the name and trigger for defining a private function. This commit changes `defprotocol`s trigger to `defpro` instead, thereby resolving the conflict.